### PR TITLE
Add gallery example page and migrate to Tailwind 4

### DIFF
--- a/app/elements/button/button.css
+++ b/app/elements/button/button.css
@@ -2,7 +2,7 @@
 
 /* Base button styles */
 ui-button button {
-	@apply inline-flex items-center justify-center border font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 cursor-pointer;
+	@apply inline-flex items-center justify-center border font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 cursor-pointer leading-none;
 }
 
 /* Size variants */

--- a/app/elements/gallery/gallery.css
+++ b/app/elements/gallery/gallery.css
@@ -1,1 +1,72 @@
-*,::backdrop,:after,:before{--tw-border-spacing-x:0;--tw-border-spacing-y:0;--tw-translate-x:0;--tw-translate-y:0;--tw-rotate:0;--tw-skew-x:0;--tw-skew-y:0;--tw-scale-x:1;--tw-scale-y:1;--tw-pan-x: ;--tw-pan-y: ;--tw-pinch-zoom: ;--tw-scroll-snap-strictness:proximity;--tw-gradient-from-position: ;--tw-gradient-via-position: ;--tw-gradient-to-position: ;--tw-ordinal: ;--tw-slashed-zero: ;--tw-numeric-figure: ;--tw-numeric-spacing: ;--tw-numeric-fraction: ;--tw-ring-inset: ;--tw-ring-offset-width:0px;--tw-ring-offset-color:#fff;--tw-ring-color:#3b82f680;--tw-ring-offset-shadow:0 0 #0000;--tw-ring-shadow:0 0 #0000;--tw-shadow:0 0 #0000;--tw-shadow-colored:0 0 #0000;--tw-blur: ;--tw-brightness: ;--tw-contrast: ;--tw-grayscale: ;--tw-hue-rotate: ;--tw-invert: ;--tw-saturate: ;--tw-sepia: ;--tw-drop-shadow: ;--tw-backdrop-blur: ;--tw-backdrop-brightness: ;--tw-backdrop-contrast: ;--tw-backdrop-grayscale: ;--tw-backdrop-hue-rotate: ;--tw-backdrop-invert: ;--tw-backdrop-opacity: ;--tw-backdrop-saturate: ;--tw-backdrop-sepia: ;--tw-contain-size: ;--tw-contain-layout: ;--tw-contain-paint: ;--tw-contain-style: }.\!visible{visibility:visible!important}.visible{visibility:visible}.static{position:static}.mb-8{margin-bottom:2rem}.flex{display:flex}.grid{display:grid}.hidden{display:none}.grid-cols-1{grid-template-columns:repeat(1,minmax(0,1fr))}.grid-cols-2{grid-template-columns:repeat(2,minmax(0,1fr))}.grid-cols-3{grid-template-columns:repeat(3,minmax(0,1fr))}.grid-cols-4{grid-template-columns:repeat(4,minmax(0,1fr))}.grid-cols-5{grid-template-columns:repeat(5,minmax(0,1fr))}.grid-cols-6{grid-template-columns:repeat(6,minmax(0,1fr))}.flex-wrap{flex-wrap:wrap}.gap-2{gap:.5rem}.gap-6{gap:1.5rem}.rounded{border-radius:.25rem}.filter{filter:var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow)}@media (min-width:640px){.sm\:grid-cols-1{grid-template-columns:repeat(1,minmax(0,1fr))}.sm\:grid-cols-2{grid-template-columns:repeat(2,minmax(0,1fr))}}@media (min-width:768px){.md\:grid-cols-1{grid-template-columns:repeat(1,minmax(0,1fr))}.md\:grid-cols-2{grid-template-columns:repeat(2,minmax(0,1fr))}.md\:grid-cols-3{grid-template-columns:repeat(3,minmax(0,1fr))}}@media (min-width:1024px){.lg\:grid-cols-1{grid-template-columns:repeat(1,minmax(0,1fr))}.lg\:grid-cols-2{grid-template-columns:repeat(2,minmax(0,1fr))}.lg\:grid-cols-3{grid-template-columns:repeat(3,minmax(0,1fr))}.lg\:grid-cols-4{grid-template-columns:repeat(4,minmax(0,1fr))}.lg\:grid-cols-5{grid-template-columns:repeat(5,minmax(0,1fr))}.lg\:grid-cols-6{grid-template-columns:repeat(6,minmax(0,1fr))}}
+@reference 'tailwindcss';
+
+/* Filter button bar */
+.gallery-filters {
+	@apply flex flex-wrap gap-2 mb-8;
+}
+
+/* Grid base — mobile first, single column */
+.gallery-grid {
+	@apply grid grid-cols-1 gap-6;
+}
+
+/* Responsive columns via data-columns on the host.
+   Mobile = min(columns, 2), tablet = min(columns, 3), desktop = columns */
+:host([data-columns='1']) .gallery-grid {
+	@apply sm:grid-cols-1 md:grid-cols-1 lg:grid-cols-1;
+}
+
+:host([data-columns='2']) .gallery-grid {
+	@apply sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-2;
+}
+
+:host([data-columns='3']) .gallery-grid {
+	@apply sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3;
+}
+
+:host([data-columns='4']) .gallery-grid {
+	@apply sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4;
+}
+
+:host([data-columns='5']) .gallery-grid {
+	@apply sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5;
+}
+
+:host([data-columns='6']) .gallery-grid {
+	@apply sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-6;
+}
+
+/* Button styles — ui-button renders inside this shadow root so global CSS can't reach it */
+ui-button button {
+	@apply inline-flex items-center justify-center border transition-colors cursor-pointer;
+	font-family: inherit;
+	font-weight: 500;
+}
+
+ui-button[data-size='small'] button {
+	@apply text-sm px-3 py-1;
+}
+
+ui-button[data-size='medium'] button {
+	@apply text-sm px-4 py-3;
+}
+
+ui-button[data-size='large'] button {
+	@apply text-base px-5 py-4;
+}
+
+ui-button[data-shape='square'] button {
+	@apply rounded-lg;
+}
+
+ui-button[data-shape='rounded'] button {
+	@apply rounded-full shadow-sm;
+}
+
+ui-button[data-variant='primary'] button {
+	@apply bg-zinc-900 hover:bg-zinc-700 border-zinc-900 text-white;
+}
+
+ui-button[data-variant='secondary'] button {
+	@apply bg-white hover:bg-zinc-100 border-zinc-200 text-zinc-900;
+}

--- a/app/elements/gallery/gallery.ts
+++ b/app/elements/gallery/gallery.ts
@@ -2,15 +2,14 @@ import { LitElement, html, css, unsafeCSS } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import { chargedCustomElement } from '../registry';
 import { animate, stagger } from 'motion';
-import clsx from 'clsx';
-import styles from './gallery.css?raw';
+import styles from './gallery.css?inline';
 
 import '../button/index';
 
 type FilterItem = { id: string; label: string };
 
 export type GalleryProps = {
-	columns?: number;
+	'data-columns'?: number;
 	allLabel?: string;
 } & React.HTMLAttributes<HTMLElement>;
 
@@ -20,7 +19,7 @@ export class UIGallery extends LitElement {
 		${unsafeCSS(styles)}
 	`;
 
-	@property({ type: Number })
+	@property({ type: Number, attribute: 'data-columns', reflect: true })
 	columns = 4;
 
 	@property({ type: String })
@@ -31,30 +30,6 @@ export class UIGallery extends LitElement {
 
 	@state()
 	private filters: FilterItem[] = [];
-
-	get gridClasses(): string {
-		const mobileColumns = Math.min(this.columns, 2);
-		const tabletColumns = Math.min(this.columns, 3);
-		const desktopColumns = this.columns;
-
-		const gridStyles = clsx({
-			'sm:grid-cols-1': mobileColumns === 1,
-			'sm:grid-cols-2': mobileColumns === 2,
-
-			'md:grid-cols-1': tabletColumns === 1,
-			'md:grid-cols-2': tabletColumns === 2,
-			'md:grid-cols-3': tabletColumns === 3,
-
-			'lg:grid-cols-1': desktopColumns === 1,
-			'lg:grid-cols-2': desktopColumns === 2,
-			'lg:grid-cols-3': desktopColumns === 3,
-			'lg:grid-cols-4': desktopColumns === 4,
-			'lg:grid-cols-5': desktopColumns === 5,
-			'lg:grid-cols-6': desktopColumns === 6,
-		});
-
-		return `grid grid-cols-1 ${gridStyles} gap-6`;
-	}
 
 	detectFiltersFromChildren(): void {
 		const slot = this.shadowRoot?.querySelector('slot');
@@ -86,7 +61,6 @@ export class UIGallery extends LitElement {
 		return category
 			.split(' ')
 			.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-			.slice(0, 1)
 			.join(' ');
 	}
 
@@ -127,7 +101,7 @@ export class UIGallery extends LitElement {
 		animate(
 			visibleItems,
 			{ opacity: [0, 1], scale: [0.8, 1] },
-			{ delay: stagger(0.05, { ease: [0.4, 0.0, 0.2, 1] }) }
+			{ delay: stagger(0.05, { ease: [0.4, 0.0, 0.2, 1] }) },
 		);
 	}
 
@@ -157,26 +131,26 @@ export class UIGallery extends LitElement {
 		return html`
 			${this.filters.length > 1
 				? html`
-						<div class="flex flex-wrap gap-2 mb-8">
+						<div class="gallery-filters">
 							${this.filters.map(
 								(filter) => html`
 									<ui-button
 										@click=${() => this.setFilter(filter.id)}
-										size="small"
-										variant=${this.activeFilter === filter.id
+										data-size="small"
+										data-variant=${this.activeFilter === filter.id
 											? 'primary'
 											: 'secondary'}
-										shape="rounded"
+										data-shape="rounded"
 									>
-										<div slot="value">${filter.label}</div>
+										<button>${filter.label}</button>
 									</ui-button>
-								`
+								`,
 							)}
 						</div>
 					`
 				: ''}
 
-			<div class="${this.gridClasses}">
+			<div class="gallery-grid">
 				<slot @slotchange=${() => this.handleSlotChange()}></slot>
 			</div>
 		`;

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -22,6 +22,7 @@ export default [
 			route('dots', 'routes/elements/dots.tsx'),
 			route('draggable', 'routes/elements/draggable.tsx'),
 			route('droppable', 'routes/elements/droppable.tsx'),
+			route('gallery', 'routes/elements/gallery.tsx'),
 			route('globe', 'routes/elements/globe.tsx'),
 			route('icon', 'routes/elements/icon.tsx'),
 			route('icon-selector', 'routes/elements/icon-selector.tsx'),

--- a/app/routes/elements/gallery.tsx
+++ b/app/routes/elements/gallery.tsx
@@ -1,0 +1,279 @@
+import type { Route } from './+types/alert';
+import '~/elements/gallery';
+import '~/elements/card';
+import '~/elements/icon';
+import '~/elements/button';
+
+export function meta({}: Route.MetaArgs) {
+	return [{ title: 'Charged | Gallery' }];
+}
+
+export default function Gallery() {
+	return (
+		<ui-gallery data-columns={2}>
+			<ui-card
+				data-categories="design,marketing"
+				class="grid-item group hover:shadow-sm duration-300 ease-out rounded-xl relative overflow-hidden cursor-pointer"
+			>
+				<img
+					src="https://flowbite.s3.amazonaws.com/docs/gallery/square/image-1.jpg"
+					alt="Brand Refresh"
+					slot="media"
+					class="group-hover:scale-105 duration-300 ease-out transition-all"
+				/>
+				<div
+					slot="footer"
+					class="bg-white relative z-1 flex items-center p-4 font-medium"
+				>
+					Brand Refresh
+					<ui-icon
+						name="arrow-top-right-on-square"
+						class="ml-auto opacity-0 group-hover:opacity-100 duration-300 ease-out transition-all"
+					/>
+				</div>
+			</ui-card>
+
+			<ui-card
+				data-categories="apps,design"
+				class="grid-item group hover:shadow-sm duration-300 ease-out rounded-xl relative overflow-hidden cursor-pointer"
+			>
+				<img
+					src="https://flowbite.s3.amazonaws.com/docs/gallery/square/image-4.jpg"
+					alt="Mobile App"
+					slot="media"
+					class="group-hover:scale-105 duration-300 ease-out transition-all"
+				/>
+				<div
+					slot="footer"
+					class="bg-white relative z-1 flex items-center p-4 font-medium"
+				>
+					Mobile App
+					<ui-icon
+						name="arrow-top-right-on-square"
+						class="ml-auto opacity-0 group-hover:opacity-100 duration-300 ease-out transition-all"
+					/>
+				</div>
+			</ui-card>
+
+			<ui-card
+				data-categories="marketing"
+				class="grid-item group hover:shadow-sm duration-300 ease-out rounded-xl relative overflow-hidden cursor-pointer"
+			>
+				<img
+					src="https://flowbite.s3.amazonaws.com/docs/gallery/square/image-2.jpg"
+					alt="Campaign Strategy"
+					slot="media"
+					class="group-hover:scale-105 duration-300 ease-out transition-all"
+				/>
+				<div
+					slot="footer"
+					class="bg-white relative z-1 flex items-center p-4 font-medium"
+				>
+					Campaign Strategy
+					<ui-icon
+						name="arrow-top-right-on-square"
+						class="ml-auto opacity-0 group-hover:opacity-100 duration-300 ease-out transition-all"
+					/>
+				</div>
+			</ui-card>
+
+			<ui-card
+				data-categories="packaging,design"
+				class="grid-item group hover:shadow-sm duration-300 ease-out rounded-xl relative overflow-hidden cursor-pointer"
+			>
+				<img
+					src="https://flowbite.s3.amazonaws.com/docs/gallery/square/image-3.jpg"
+					alt="Sustainable Packaging"
+					slot="media"
+					class="group-hover:scale-105 duration-300 ease-out transition-all"
+				/>
+				<div
+					slot="footer"
+					class="bg-white relative z-1 flex items-center p-4 font-medium"
+				>
+					Sustainable Packaging
+					<ui-icon
+						name="arrow-top-right-on-square"
+						class="ml-auto opacity-0 group-hover:opacity-100 duration-300 ease-out transition-all"
+					/>
+				</div>
+			</ui-card>
+
+			<ui-card
+				data-categories="design"
+				class="grid-item group hover:shadow-sm duration-300 ease-out rounded-xl relative overflow-hidden cursor-pointer"
+			>
+				<img
+					src="https://flowbite.s3.amazonaws.com/docs/gallery/square/image-5.jpg"
+					alt="Web Design"
+					slot="media"
+					class="group-hover:scale-105 duration-300 ease-out transition-all"
+				/>
+				<div
+					slot="footer"
+					class="bg-white relative z-1 flex items-center p-4 font-medium"
+				>
+					Web Design
+					<ui-icon
+						name="arrow-top-right-on-square"
+						class="ml-auto opacity-0 group-hover:opacity-100 duration-300 ease-out transition-all"
+					/>
+				</div>
+			</ui-card>
+
+			<ui-card
+				data-categories="marketing,design"
+				class="grid-item group hover:shadow-sm duration-300 ease-out rounded-xl relative overflow-hidden cursor-pointer"
+			>
+				<img
+					src="https://flowbite.s3.amazonaws.com/docs/gallery/square/image-6.jpg"
+					alt="Social Media Kit"
+					slot="media"
+					class="group-hover:scale-105 duration-300 ease-out transition-all"
+				/>
+				<div
+					slot="footer"
+					class="bg-white relative z-1 flex items-center p-4 font-medium"
+				>
+					Social Media Kit
+					<ui-icon
+						name="arrow-top-right-on-square"
+						class="ml-auto opacity-0 group-hover:opacity-100 duration-300 ease-out transition-all"
+					/>
+				</div>
+			</ui-card>
+
+			<ui-card
+				data-categories="design,apps"
+				class="grid-item group hover:shadow-sm duration-300 ease-out rounded-xl relative overflow-hidden cursor-pointer"
+			>
+				<img
+					src="https://flowbite.s3.amazonaws.com/docs/gallery/square/image-7.jpg"
+					alt="Dashboard UI"
+					slot="media"
+					class="group-hover:scale-105 duration-300 ease-out transition-all"
+				/>
+				<div
+					slot="footer"
+					class="bg-white relative z-1 flex items-center p-4 font-medium"
+				>
+					Dashboard UI
+					<ui-icon
+						name="arrow-top-right-on-square"
+						class="ml-auto opacity-0 group-hover:opacity-100 duration-300 ease-out transition-all"
+					/>
+				</div>
+			</ui-card>
+
+			<ui-card
+				data-categories="apps"
+				class="grid-item group hover:shadow-sm duration-300 ease-out rounded-xl relative overflow-hidden cursor-pointer"
+			>
+				<img
+					src="https://flowbite.s3.amazonaws.com/docs/gallery/square/image-8.jpg"
+					alt="Plugin Development"
+					slot="media"
+					class="group-hover:scale-105 duration-300 ease-out transition-all"
+				/>
+				<div
+					slot="footer"
+					class="bg-white relative z-1 flex items-center p-4 font-medium"
+				>
+					Plugin Development
+					<ui-icon
+						name="arrow-top-right-on-square"
+						class="ml-auto opacity-0 group-hover:opacity-100 duration-300 ease-out transition-all"
+					/>
+				</div>
+			</ui-card>
+
+			<ui-card
+				data-categories="marketing,packaging"
+				class="grid-item group hover:shadow-sm duration-300 ease-out rounded-xl relative overflow-hidden cursor-pointer"
+			>
+				<img
+					src="https://flowbite.s3.amazonaws.com/docs/gallery/square/image-9.jpg"
+					alt="Product Launch"
+					slot="media"
+					class="group-hover:scale-105 duration-300 ease-out transition-all"
+				/>
+				<div
+					slot="footer"
+					class="bg-white relative z-1 flex items-center p-4 font-medium"
+				>
+					Product Launch
+					<ui-icon
+						name="arrow-top-right-on-square"
+						class="ml-auto opacity-0 group-hover:opacity-100 duration-300 ease-out transition-all"
+					/>
+				</div>
+			</ui-card>
+
+			<ui-card
+				data-categories="design,apps"
+				class="grid-item group hover:shadow-sm duration-300 ease-out rounded-xl relative overflow-hidden cursor-pointer"
+			>
+				<img
+					src="https://flowbite.s3.amazonaws.com/docs/gallery/square/image-10.jpg"
+					alt="UX Research"
+					slot="media"
+					class="group-hover:scale-105 duration-300 ease-out transition-all"
+				/>
+				<div
+					slot="footer"
+					class="bg-white relative z-1 flex items-center p-4 font-medium"
+				>
+					UX Research
+					<ui-icon
+						name="arrow-top-right-on-square"
+						class="ml-auto opacity-0 group-hover:opacity-100 duration-300 ease-out transition-all"
+					/>
+				</div>
+			</ui-card>
+
+			<ui-card
+				data-categories="packaging"
+				class="grid-item group hover:shadow-sm duration-300 ease-out rounded-xl relative overflow-hidden cursor-pointer"
+			>
+				<img
+					src="https://flowbite.s3.amazonaws.com/docs/gallery/square/image-11.jpg"
+					alt="Retail Packaging"
+					slot="media"
+					class="group-hover:scale-105 duration-300 ease-out transition-all"
+				/>
+				<div
+					slot="footer"
+					class="bg-white relative z-1 flex items-center p-4 font-medium"
+				>
+					Retail Packaging
+					<ui-icon
+						name="arrow-top-right-on-square"
+						class="ml-auto opacity-0 group-hover:opacity-100 duration-300 ease-out transition-all"
+					/>
+				</div>
+			</ui-card>
+
+			<ui-card
+				data-categories="marketing,apps"
+				class="grid-item group hover:shadow-sm duration-300 ease-out rounded-xl relative overflow-hidden cursor-pointer"
+			>
+				<img
+					src="https://flowbite.s3.amazonaws.com/docs/gallery/square/image.jpg"
+					alt="Marketing Automation"
+					slot="media"
+					class="group-hover:scale-105 duration-300 ease-out transition-all"
+				/>
+				<div
+					slot="footer"
+					class="bg-white relative z-1 flex items-center p-4 font-medium"
+				>
+					Marketing Automation
+					<ui-icon
+						name="arrow-top-right-on-square"
+						class="ml-auto opacity-0 group-hover:opacity-100 duration-300 ease-out transition-all"
+					/>
+				</div>
+			</ui-card>
+		</ui-gallery>
+	);
+}


### PR DESCRIPTION
## Summary

- Adds a new `/elements/gallery` route with a 12-card filterable portfolio example using real images, `ui-card`, and `ui-icon`
- Rewrites `gallery.css` as a proper Tailwind 4 source file using `@reference` and `@apply` with `:host([data-columns])` selectors for responsive grid layout
- Switches the CSS import from `?raw` to `?inline` so Vite processes the file through Tailwind before injecting into the shadow DOM
- Migrates the `columns` prop to `data-columns` attribute with `reflect: true`, removing the `clsx`/`gridClasses` approach in favour of pure CSS
- Scopes button and filter bar styles inside the gallery shadow DOM, fixing font-family and font-weight inheritance issues caused by browser UA stylesheet defaults

## Test plan

- [ ] Visit `/elements/gallery` and confirm 2-column grid renders correctly
- [ ] Click filter buttons (Apps, Design, Marketing, Packaging) and confirm filtering + stagger animations work
- [ ] Confirm filter button text renders in Inter at weight 500 (not Arial)
- [ ] Resize viewport and confirm responsive column breakpoints apply correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)